### PR TITLE
🛠 Support AIW

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planable/commitlint-config",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Commitlint configs used in Planable projects",
   "main": "dist/index.js",
   "files": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ const anyEmojiWithSpaceAfter =
   /^([\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}](?:[\u{fe00}-\u{fe0f}])?)\s/u;
 const optionalPlanableTicketWithSpaceAfter = /(?:\[(.+)\]\s)?/;
 const subjectThatDoesNotStartsWithBracket =
-  /([^[\d\s][a-zA-Z](?:(?!\[P-\d|SER-\d|MOB-\d).)*)$/;
+  /([^[\d\s][a-zA-Z](?:(?!\[P-\d|SER-\d|MOB-\d|AIW-\d).)*)$/;
 
 const headerMatchPlanablePattern: Rule = (parsed: Commit) => {
   const { type, ticket, subject } = parsed;
@@ -31,14 +31,14 @@ const headerMatchPlanablePattern: Rule = (parsed: Commit) => {
 };
 
 const ticketPattern: Rule = (parsed: Commit) => {
-  const planableTicket = /(^P-\d+$)|(^SER-\d+$)|(^MOB-\d+$)/;
+  const planableTicket = /(^P-\d+$)|(^SER-\d+$)|(^MOB-\d+$)|(^AIW-\d+$)/;
 
   const { ticket } = parsed;
   if (ticket) {
     if (!planableTicket.test(ticket)) {
       return [
         false,
-        "ticket must be in format of a valid Linear issue, for example: [P-11], [SER-123] or [MOB-22]",
+        "ticket must be in format of a valid Linear issue, for example: [P-11], [SER-123], [MOB-22] or [AIW-49]",
       ];
     }
   }


### PR DESCRIPTION
## Summary

Adds `AIW-*` as a valid Linear ticket prefix in commitlint, following the same pattern as [MOB support (#15)](https://github.com/Planable/commitlint-config/pull/15).

## Changes

- `src/config.ts`: add `AIW-\d` to subject parser negative lookahead, ticket regex, and error message
- `package.json`: bump version to `1.2.10`

## Test plan

- [x] `npm test` passes locally
- [ ] After publish, bump `@planable/commitlint-config` in `planable-app` and verify `🛠 [AIW-49] ...` PR titles pass CI


Made with [Cursor](https://cursor.com)