### PR TITLE
🛠 Fix publish build by pinning @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@commitlint/lint": "^16.0.0",
     "@commitlint/types": "^16.0.0",
     "@types/jest": "^27.4.0",
+    "@types/node": "^18.19.0",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "eslint": "^8.18.0",
@@ -26,6 +27,6 @@
     "jest": "^27.4.7",
     "symlink-config": "^0.2.0",
     "ts-jest": "^27.1.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the Publish workflow failure after #16 by pinning compatible `@types/node` and bumping TypeScript so `npm install` / `tsc` succeed on CI.

## Test plan

- [x] `npm install && npm run build && npm test` pass locally
- [ ] Publish workflow succeeds on merge and `1.2.10` is available on GitHub Packages


Made with [Cursor](https://cursor.com)